### PR TITLE
immediate=true not implemented for basic.publish since rabbitmq 3.0

### DIFF
--- a/src/Delivery/SchedulerDeliveryOptions.php
+++ b/src/Delivery/SchedulerDeliveryOptions.php
@@ -56,7 +56,7 @@ final class SchedulerDeliveryOptions implements DeliveryOptions
 
     public function isHighestPriority(): bool
     {
-        return true;
+        return false;
     }
 
     public function expirationAfter(): ?int


### PR DESCRIPTION
Rabbitmq server just close connection when app is trying to publish message with immediate flag.
Seems like this option was [removed](https://www.rabbitmq.com/blog/2012/11/19/breaking-things-with-rabbitmq-3-0/) in rabbitmq 3.0